### PR TITLE
Adjust provider code to refactored Keycloak code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,12 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.keycloak:keycloak-core:20.0.1'
-    compileOnly 'org.keycloak:keycloak-server-spi:20.0.1'
-    compileOnly 'org.keycloak:keycloak-server-spi-private:20.0.1'
-    compileOnly 'org.keycloak:keycloak-services:20.0.1'
+    compileOnly 'org.keycloak:keycloak-core:21.0.2'
+    compileOnly 'org.keycloak:keycloak-server-spi:21.0.2'
+    compileOnly 'org.keycloak:keycloak-server-spi-private:21.0.2'
+    compileOnly 'org.keycloak:keycloak-services:21.0.2'
 
-    testImplementation 'org.keycloak:keycloak-services:20.0.1'
+    testImplementation 'org.keycloak:keycloak-services:21.0.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'at.klausbetz'
-version '1.4.1'
+version '1.5.0'
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {

--- a/src/main/java/at/klausbetz/provider/AppleIdentityProvider.java
+++ b/src/main/java/at/klausbetz/provider/AppleIdentityProvider.java
@@ -68,7 +68,7 @@ public class AppleIdentityProvider extends OIDCIdentityProvider implements Socia
 
     @Override
     public Object callback(RealmModel realm, AuthenticationCallback callback, EventBuilder event) {
-        return new AppleIdentityProviderEndpoint(this, realm, callback, event);
+        return new AppleIdentityProviderEndpoint(this, realm, callback, event, session, session.getContext().getConnection());
     }
 
     @Override

--- a/src/main/java/at/klausbetz/provider/AppleIdentityProviderEndpoint.java
+++ b/src/main/java/at/klausbetz/provider/AppleIdentityProviderEndpoint.java
@@ -39,20 +39,20 @@ public class AppleIdentityProviderEndpoint {
     private final IdentityProvider.AuthenticationCallback callback;
     private final EventBuilder event;
 
-    @Context
     protected KeycloakSession session;
 
-    @Context
     protected ClientConnection clientConnection;
 
     @Context
     protected HttpHeaders headers;
 
-    public AppleIdentityProviderEndpoint(AppleIdentityProvider appleIdentityProvider, RealmModel realm, IdentityProvider.AuthenticationCallback callback, EventBuilder event) {
+    public AppleIdentityProviderEndpoint(AppleIdentityProvider appleIdentityProvider, RealmModel realm, IdentityProvider.AuthenticationCallback callback, EventBuilder event, KeycloakSession session, ClientConnection clientConnection) {
         this.appleIdentityProvider = appleIdentityProvider;
         this.realm = realm;
         this.callback = callback;
         this.event = event;
+        this.session = session;
+        this.clientConnection = clientConnection;
     }
 
     @POST


### PR DESCRIPTION
Fixes https://github.com/klausbetz/apple-identity-provider-keycloak/issues/35.

**Disclaimer**
This is not by any means code to be merged as-is, as it would certainly break compatibility with Keycloak versions lower than 21.

Recently the following change was [introduced](https://github.com/keycloak/keycloak/pull/15451/files#diff-bac0e59c0cd0e28567be1faa0d9e80772ce6673025e8bd7ad5117728c8d2b15c) in the Keycloak code. To my understanding this altered the way `session` and `clientConnection` were initialized, causing `NullPointerException`.

I have no idea about Java but with these changes made to the provider I was able to log in with Apple using Keycloak 21.0.2.