### PR TITLE
WIP chore: update to keycloak v23.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 group 'at.klausbetz'
-version '1.8.0'
+version '1.9.0'
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 ext {
-    keycloakVersion = '23.0.0'
+    keycloakVersion = '23.0.3'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ version '1.8.0'
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 ext {
-    keycloakVersion = '22.0.2'
+    keycloakVersion = '23.0.0'
 }
 
 repositories {


### PR DESCRIPTION
Needs testing. In theory v1.7.1 should still be compatible to Keycloak v23 without any changes.