### PR TITLE
Add support for Keycloak 23.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ version '1.8.0'
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 ext {
-    keycloakVersion = '22.0.2'
+    keycloakVersion = '23.0.3'
 }
 
 repositories {


### PR DESCRIPTION
This will resolve the 405 Method not found error after being redirect back from apple.

This comment got me in the right direction: https://github.com/keycloak/keycloak/issues/23444#issuecomment-1787524388

This will fix issue https://github.com/klausbetz/apple-identity-provider-keycloak/issues/60