### PR TITLE
Add a user attribute mapper

### DIFF
--- a/src/main/java/at/klausbetz/provider/AppleUserAttributeMapper.java
+++ b/src/main/java/at/klausbetz/provider/AppleUserAttributeMapper.java
@@ -1,0 +1,19 @@
+package at.klausbetz.provider;
+
+import org.keycloak.broker.oidc.mappers.UserAttributeMapper;
+
+public class AppleUserAttributeMapper extends UserAttributeMapper {
+
+    private static final String[] cp = new String[] { AppleIdentityProviderFactory.PROVIDER_ID };
+
+    @Override
+    public String[] getCompatibleProviders() {
+        return cp;
+    }
+
+
+    @Override
+    public String getId() {
+            return "apple-user-attribute-mapper";
+        }
+}

--- a/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
+++ b/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
@@ -1,1 +1,2 @@
 at.klausbetz.provider.AppleUsernameTemplateMapper
+at.klausbetz.provider.AppleUserAttributeMapper


### PR DESCRIPTION
So you can, say, map `sub` to a custom user attribute.