### PR TITLE
Update for Keycloak 25.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ version '1.12.0'
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 ext {
-    keycloakVersion = '24.0.5'
+    keycloakVersion = '25.0.0'
 }
 
 repositories {

--- a/src/main/java/at/klausbetz/provider/AppleIdentityProvider.java
+++ b/src/main/java/at/klausbetz/provider/AppleIdentityProvider.java
@@ -134,7 +134,6 @@ public class AppleIdentityProvider extends OIDCIdentityProvider implements Socia
             context.getContextData().put(VALIDATED_ID_TOKEN, parsedToken);
             context.getContextData().put(EXCHANGE_PROVIDER, getConfig().getAlias());
             context.setIdp(this);
-            context.setIdpConfig(getConfig());
             return context;
         } catch (IOException e) {
             logger.debug("Unable to extract identity from identity token", e);
@@ -164,7 +163,6 @@ public class AppleIdentityProvider extends OIDCIdentityProvider implements Socia
         }
 
         BrokeredIdentityContext federatedIdentity = getFederatedIdentity(userDataJson, response.asString());
-        federatedIdentity.setIdpConfig(getConfig());
         federatedIdentity.setIdp(AppleIdentityProvider.this);
         federatedIdentity.setAuthenticationSession(authSession);
         return federatedIdentity;


### PR DESCRIPTION
Since Keycloak 25, specifically
bbb83236f5251e3c4718eac63ab0e640a80913f1, the idp config is passed into the constructor of BrokeredIdentityContext instead of using a setter method later. Changes here are analogous to OIDCIdentityProvider.

Tested manually with both "regular" web login (goes through `sendTokenRequest()`) and token exchange (goes through `validateAppleIdToken()`).