### PR TITLE
Add missing required feature to dockerfile

### DIFF
--- a/docs/README_docker_installation.md
+++ b/docs/README_docker_installation.md
@@ -1,13 +1,13 @@
 # Running Keycloak and Apple Identity Provider in a container
 
 The following `Dockerfile` creates a pre-configured Keycloak image that enables the health and metrics endpoints, 
-enables the token exchange feature, uses a PostgreSQL database and installs Apple Identity Provider extension:
+enables the token exchange feature and the Fine-Grained Admin Permissions, uses a PostgreSQL database and installs Apple Identity Provider extension:
 
 ```Dockerfile
 FROM quay.io/keycloak/keycloak:22.0.1 as builder
 
 ENV KC_HEALTH_ENABLED=true
-ENV KC_FEATURES=token-exchange
+ENV KC_FEATURES=token-exchange,admin-fine-grained-authz
 ENV KC_DB=postgres
 ENV KC_HTTP_RELATIVE_PATH="/auth"
 


### PR DESCRIPTION
As required in [Keycloak documentation](https://www.keycloak.org/securing-apps/token-exchange#_external_token_to_internal_token_exchange) to exchange external token with an internal one we also need to enable `admin-fine-grained-authz` feature, so then we can [Granting permission for the exchange](https://www.keycloak.org/securing-apps/token-exchange#_client_to_client_permission)