### PR TITLE
Update Keycloak version to 26.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ See compatibility list below to find the version that suits your Keycloak versio
 | `21.1.0 <= 21.1.2` :information_source: | `1.6.0`                           |
 | `22.0.0 < 23.0.0`                       | `1.7.0 <= 1.8.0`                  |
 | `23.0.0 < 25.0.0`                       | `1.9.0 <= 1.12.0`                 |
-| `>= 25.0.0`                             | `>= 1.13.0`                       |
+| `25.0.0 < 26.2.3`                       | `1.13.0 <= 1.14.0`                |
+| `>= 26.3.0`                             | `>= 1.15.0`                       |
 
 :information_source: In Keycloak `v21.X.Y` this extension cannot be used effectively, since the additional properties such
 as `Team ID`, `Key ID`

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,10 @@ plugins {
 
 group 'at.klausbetz'
 version '1.14.0'
-java.sourceCompatibility = JavaVersion.VERSION_11
+java.sourceCompatibility = JavaVersion.VERSION_17
 
 ext {
-    keycloakVersion = '25.0.0'
+    keycloakVersion = '26.3.0'
 }
 
 repositories {

--- a/src/main/java/at/klausbetz/provider/AppleIdentityProvider.java
+++ b/src/main/java/at/klausbetz/provider/AppleIdentityProvider.java
@@ -78,7 +78,7 @@ public class AppleIdentityProvider extends OIDCIdentityProvider implements Socia
     }
 
     @Override
-    protected BrokeredIdentityContext exchangeExternalImpl(EventBuilder event, MultivaluedMap<String, String> params) {
+    protected BrokeredIdentityContext exchangeExternalTokenV1Impl(EventBuilder event, MultivaluedMap<String, String> params) {
         TokenExchangeParams exchangeParams = new TokenExchangeParams(params);
         if (exchangeParams.getSubjectToken() == null) {
             event.detail(Details.REASON, OAuth2Constants.SUBJECT_TOKEN + " param unset");

--- a/src/main/java/at/klausbetz/provider/AppleIdentityProviderEndpoint.java
+++ b/src/main/java/at/klausbetz/provider/AppleIdentityProviderEndpoint.java
@@ -68,9 +68,9 @@ public class AppleIdentityProviderEndpoint {
                 sendErrorEvent();
                 return callback.cancelled(this.appleIdentityProvider.getConfig());
             } else if (error.equals(OAuthErrorException.LOGIN_REQUIRED) || error.equals(OAuthErrorException.INTERACTION_REQUIRED)) {
-                return callback.error(error);
+                return callback.error(appleIdentityProvider.getConfig(), error);
             } else {
-                return callback.error(Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
+                return callback.error(appleIdentityProvider.getConfig(), Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
             }
         }
 


### PR DESCRIPTION
Hey @klausbetz, I checked out the newest version of Keycloak, and it seems like the `IdentityProvider` Interface changed and also the `OIDCIdentityProvider` class.

This PR should make the extension compatible with the newest version.

Please let me know if I missed something.