### PR TITLE
Custom redirect URI for token exchange flow

### DIFF
--- a/src/main/java/at/klausbetz/provider/AppleIdentityProvider.java
+++ b/src/main/java/at/klausbetz/provider/AppleIdentityProvider.java
@@ -1,5 +1,7 @@
 package at.klausbetz.provider;
 
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.UserModel;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -234,12 +236,26 @@ public class AppleIdentityProvider extends OIDCIdentityProvider implements Socia
     public SimpleHttp generateTokenRequest(String authorizationCode, String clientId) {
         KeycloakContext context = session.getContext();
         VaultStringSecret clientSecret = session.vault().getStringSecret(getConfig().getClientSecret());
+        String redirectUri = resolveRedirectUri(context, getConfig());
+
         return SimpleHttp.doPost(getConfig().getTokenUrl(), session)
                          .param(OAUTH2_PARAMETER_CODE, authorizationCode)
-                         .param(OAUTH2_PARAMETER_REDIRECT_URI, Urls.identityProviderAuthnResponse(context.getUri().getBaseUri(), getConfig().getAlias(), context.getRealm().getName()).toString())
+                         .param(OAUTH2_PARAMETER_REDIRECT_URI, redirectUri)
                          .param(OAUTH2_PARAMETER_GRANT_TYPE, OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE)
                          .param(OAUTH2_PARAMETER_CLIENT_ID, clientId)
                          .param(OAUTH2_PARAMETER_CLIENT_SECRET, clientSecret.get().orElse(getConfig().getClientSecret()));
+    }
+
+    private String resolveRedirectUri(KeycloakContext context, AppleIdentityProviderConfig cfg) {
+        String override = cfg != null ? cfg.getRedirectUri() : null;
+        if (override != null && !override.isBlank()) {
+            return override;
+        }
+        return Urls.identityProviderAuthnResponse(
+                context.getUri().getBaseUri(),
+                getConfig().getAlias(),
+                context.getRealm().getName()
+        ).toString();
     }
 
     private String generateJWS(String p8Content, String keyId, String teamId, String clientId) {

--- a/src/main/java/at/klausbetz/provider/AppleIdentityProviderConfig.java
+++ b/src/main/java/at/klausbetz/provider/AppleIdentityProviderConfig.java
@@ -10,6 +10,7 @@ public class AppleIdentityProviderConfig extends OIDCIdentityProviderConfig {
     private static final String DISPLAY_ICON_CLASSES = "fa fa-apple";
     private static final String DISPLAY_NAME = "displayName";
     private static final String DEFAULT_DISPLAY_NAME = "Sign in with Apple";
+    private static final String CUSTOM_REDIRECT_URI = "redirectUri";
 
     public AppleIdentityProviderConfig(IdentityProviderModel identityProviderModel) {
         super(identityProviderModel);
@@ -32,6 +33,14 @@ public class AppleIdentityProviderConfig extends OIDCIdentityProviderConfig {
 
     public void setKeyId(String keyId) {
         getConfig().put(KEY_ID, keyId);
+    }
+
+    public String getRedirectUri() {
+        return getConfig().get(CUSTOM_REDIRECT_URI);
+    }
+
+    public void setRedirectUri(String redirectUri) {
+        getConfig().put(CUSTOM_REDIRECT_URI, redirectUri);
     }
 
     @Override

--- a/src/main/java/at/klausbetz/provider/AppleIdentityProviderFactory.java
+++ b/src/main/java/at/klausbetz/provider/AppleIdentityProviderFactory.java
@@ -39,6 +39,7 @@ public class AppleIdentityProviderFactory extends AbstractIdentityProviderFactor
                                            .property().name("displayName").label("Display name").helpText("Text that is shown on the login page. Defaults to 'Sign in with Apple'").type(ProviderConfigProperty.STRING_TYPE).add()
                                            .property().name("teamId").label("Team ID").helpText("Your 10-character Team ID obtained from your Apple developer account.").type(ProviderConfigProperty.STRING_TYPE).add()
                                            .property().name("keyId").label("Key ID").helpText("A 10-character key identifier obtained from your Apple developer account.").type(ProviderConfigProperty.STRING_TYPE).add()
-                                           .build();
+                                           .property().name("redirectUri").label("Token Exchange Redirect URI (override)").helpText("Optional. If set, this URI will be used as 'redirect_uri' for Apple during code exchange.Leave empty to use the default Keycloak broker redirect URL.").type(ProviderConfigProperty.STRING_TYPE).add()
+                .build();
     }
 }


### PR DESCRIPTION
### **Problem:**
When exchanging an Apple `authorization_code` for tokens through Keycloak’s Apple Identity Provider, the plugin always sends `redirect_uri` as the Keycloak broker callback:
`https://<keycloak>/realms/<realm>/broker/<alias>/endpoint`
In flows that originate on a frontend (SPA/native) but perform the token exchange on a backend, Apple expects the same `redirect_uri` that was used to obtain the `authorization_code` (often frontend’s URL). Because the plugin hardcodes the broker URI for token exchange, Apple rejects the request with `invalid_grant` / `redirect-uri` mismatch.

### **What this PR does**

- Adds a new optional setting: “Token Exchange Redirect URI (override)”.
- If set, the plugin uses this value as the `redirect_uri` when calling Apple’s /token endpoint during token-exchange.
- If not set, behavior is unchanged (plugin continues to use the standard Keycloak broker URI).