### PR TITLE
add unit tests for apple identity provider + upgrade to java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+        uses: gradle/actions/wrapper-validation@v4
       - name: Test
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-        with:
-          arguments: test
+        run: ./gradlew test
       - name: Build JAR archive
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-        with:
-          arguments: jar
+        run: ./gradlew jar
       - uses: actions/upload-artifact@v4
         with:
           name: Package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build & release
 on:
   push:
     tags:
-      - '**'
+      - "**"
 
 jobs:
   create-release:
@@ -13,22 +13,22 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4
-      
-      - name: "Set up JDK 17"
+
+      - name: "Set up JDK 21"
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
           cache: gradle
-      
+
       - name: "Build JAR"
         run: sh gradlew jar
-      
+
       - name: "Copy JAR to tmp-artifacts"
         run: |
           mkdir tmp-artifacts
           cp build/libs/*.jar tmp-artifacts
-      
+
       - name: "Create hash files"
         run: |
           cd tmp-artifacts
@@ -37,13 +37,13 @@ jobs:
               sha512sum $jar | awk '{ print $1 }' > "${jar}.sha512"
           done
           cd ..
-      
+
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v4
         with:
           name: Package
           path: tmp-artifacts
-      
+
       - name: "Create release"
         run: gh release create ${GITHUB_REF_NAME} tmp-artifacts/* --generate-notes --verify-tag
         env:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 group 'at.klausbetz'
 version '1.17.0'
-java.sourceCompatibility = JavaVersion.VERSION_17
+java.sourceCompatibility = JavaVersion.VERSION_21
 
 ext {
     keycloakVersion = '26.5.0'
@@ -30,6 +30,9 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
 
     testImplementation "org.keycloak:keycloak-services:$keycloakVersion"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.11.0'
+    testRuntimeOnly 'org.jboss.resteasy:resteasy-core:6.2.4.Final'
 }
 
 test {
@@ -44,6 +47,6 @@ publishing {
 
 // run 'gradle wrapper' to regenerate gradle/ folder
 wrapper {
-    gradleVersion = "8.0.2"
+    gradleVersion = "8.10.2"
     distributionType = Wrapper.DistributionType.BIN
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk17
+  - openjdk21

--- a/src/test/java/at/klausbetz/provider/AppleIdentityProviderConfigTest.java
+++ b/src/test/java/at/klausbetz/provider/AppleIdentityProviderConfigTest.java
@@ -1,0 +1,90 @@
+package at.klausbetz.provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.IdentityProviderModel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AppleIdentityProviderConfigTest {
+
+    private AppleIdentityProviderConfig config;
+
+    @BeforeEach
+    void setUp() {
+        config = new AppleIdentityProviderConfig(new IdentityProviderModel());
+    }
+
+    @Test
+    void givenTeamId_whenGetTeamId_thenReturnsTeamId() {
+        config.setTeamId("ABCDE12345");
+        assertEquals("ABCDE12345", config.getTeamId());
+    }
+
+    @Test
+    void givenNoTeamId_whenGetTeamId_thenReturnsNull() {
+        assertNull(config.getTeamId());
+    }
+
+    @Test
+    void givenKeyId_whenGetKeyId_thenReturnsKeyId() {
+        config.setKeyId("KEY1234567");
+        assertEquals("KEY1234567", config.getKeyId());
+    }
+
+    @Test
+    void givenNoKeyId_whenGetKeyId_thenReturnsNull() {
+        assertNull(config.getKeyId());
+    }
+
+    @Test
+    void givenTokenExchangeAccountLinkingEnabled_whenIsEnabled_thenReturnsTrue() {
+        config.setTokenExchangeAccountLinkingEnabled(true);
+        assertTrue(config.isTokenExchangeAccountLinkingEnabled());
+    }
+
+    @Test
+    void givenTokenExchangeAccountLinkingDisabled_whenIsEnabled_thenReturnsFalse() {
+        config.setTokenExchangeAccountLinkingEnabled(false);
+        assertFalse(config.isTokenExchangeAccountLinkingEnabled());
+    }
+
+    @Test
+    void givenNoTokenExchangeAccountLinkingSetting_whenIsEnabled_thenReturnsFalse() {
+        assertFalse(config.isTokenExchangeAccountLinkingEnabled());
+    }
+
+    @Test
+    void givenCustomDisplayName_whenGetDisplayName_thenReturnsCustomName() {
+        config.setDisplayName("Apple Login");
+        assertEquals("Apple Login", config.getDisplayName());
+    }
+
+    @Test
+    void givenNoDisplayName_whenGetDisplayName_thenReturnsDefault() {
+        assertEquals("Sign in with Apple", config.getDisplayName());
+    }
+
+    @Test
+    void givenBlankDisplayName_whenGetDisplayName_thenReturnsDefault() {
+        config.setDisplayName("   ");
+        assertEquals("Sign in with Apple", config.getDisplayName());
+    }
+
+    @Test
+    void whenIsDisableUserInfoService_thenReturnsTrue() {
+        assertTrue(config.isDisableUserInfoService());
+    }
+
+    @Test
+    void whenGetDisplayIconClasses_thenReturnsFaApple() {
+        assertEquals("fa fa-apple", config.getDisplayIconClasses());
+    }
+
+    @Test
+    void givenDefaultConstructor_whenCreated_thenConfigIsUsable() {
+        AppleIdentityProviderConfig defaultConfig = new AppleIdentityProviderConfig();
+        assertNotNull(defaultConfig);
+        assertEquals("Sign in with Apple", defaultConfig.getDisplayName());
+    }
+}

--- a/src/test/java/at/klausbetz/provider/AppleIdentityProviderEndpointTest.java
+++ b/src/test/java/at/klausbetz/provider/AppleIdentityProviderEndpointTest.java
@@ -1,0 +1,217 @@
+package at.klausbetz.provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.broker.provider.IdentityProvider;
+import org.keycloak.broker.provider.UserAuthenticationIdentityProvider;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakUriInfo;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.ErrorPage;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import org.keycloak.common.util.Base64Url;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for AppleIdentityProviderEndpoint.
+ * <p>
+ * Note: jakarta.ws.rs.core.Response cannot be mocked without a JAX-RS RuntimeDelegate
+ * implementation on the classpath. The callback mock methods return null by default,
+ * which is sufficient for interaction verification.
+ */
+@ExtendWith(MockitoExtension.class)
+class AppleIdentityProviderEndpointTest {
+
+    @Mock(lenient = true)
+    private AppleIdentityProvider appleIdentityProvider;
+
+    @Mock(lenient = true)
+    private AppleIdentityProviderConfig appleConfig;
+
+    @Mock(lenient = true)
+    private RealmModel realm;
+
+    @Mock(lenient = true)
+    private UserAuthenticationIdentityProvider.AuthenticationCallback callback;
+
+    @Mock(lenient = true)
+    private EventBuilder event;
+
+    @Mock(lenient = true)
+    private KeycloakSession session;
+
+    @Mock(lenient = true)
+    private KeycloakContext keycloakContext;
+
+    @Mock(lenient = true)
+    private KeycloakUriInfo uriInfo;
+
+    @Mock(lenient = true)
+    private AuthenticationSessionModel authSession;
+
+    private AppleIdentityProviderEndpoint endpoint;
+
+    @BeforeEach
+    void setUp() {
+        when(appleIdentityProvider.getConfig()).thenReturn(appleConfig);
+        when(appleConfig.getProviderId()).thenReturn("apple");
+        when(appleConfig.getAlias()).thenReturn("apple");
+        when(appleConfig.getClientId()).thenReturn("com.example.app");
+
+        when(session.getContext()).thenReturn(keycloakContext);
+        when(keycloakContext.getUri()).thenReturn(uriInfo);
+        when(keycloakContext.getRealm()).thenReturn(realm);
+        when(realm.getName()).thenReturn("myRealm");
+        when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost:8080/auth"));
+
+        endpoint = new AppleIdentityProviderEndpoint(appleIdentityProvider, realm, callback, event, session);
+    }
+
+    // ========== Error parameter handling ==========
+
+    @Test
+    void authResponse_accessDenied_callsCancelled() {
+        String state = createValidState();
+        when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+
+        endpoint.authResponse(state, null, null, "access_denied");
+
+        verify(callback).cancelled(appleConfig);
+        verify(event).event(EventType.IDENTITY_PROVIDER_LOGIN);
+        verify(event).error(Errors.IDENTITY_PROVIDER_LOGIN_FAILURE);
+    }
+
+    @Test
+    void authResponse_userCancelledAuthorize_callsCancelled() {
+        String state = createValidState();
+        when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+
+        endpoint.authResponse(state, null, null, "user_cancelled_authorize");
+
+        verify(callback).cancelled(appleConfig);
+    }
+
+    @Test
+    void authResponse_loginRequired_callsCallbackError() {
+        String state = createValidState();
+        when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+
+        endpoint.authResponse(state, null, null, OAuthErrorException.LOGIN_REQUIRED);
+
+        verify(callback).error(appleConfig, OAuthErrorException.LOGIN_REQUIRED);
+    }
+
+    @Test
+    void authResponse_interactionRequired_callsCallbackError() {
+        String state = createValidState();
+        when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+
+        endpoint.authResponse(state, null, null, OAuthErrorException.INTERACTION_REQUIRED);
+
+        verify(callback).error(appleConfig, OAuthErrorException.INTERACTION_REQUIRED);
+    }
+
+    @Test
+    void authResponse_unknownError_callsCallbackErrorWithUnexpectedMessage() {
+        String state = createValidState();
+        when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+
+        endpoint.authResponse(state, null, null, "some_unknown_error");
+
+        verify(callback).error(eq(appleConfig), eq("identityProviderUnexpectedErrorMessage"));
+    }
+
+    // ========== Successful code exchange ==========
+
+    @Test
+    void authResponse_withAuthorizationCode_preparesSecretAndExchangesToken() throws Exception {
+        String state = createValidState();
+        BrokeredIdentityContext federatedIdentity = mock(BrokeredIdentityContext.class);
+        when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+        when(appleIdentityProvider.sendTokenRequest(anyString(), anyString(), any(), any(), anyString()))
+                .thenReturn(federatedIdentity);
+
+        endpoint.authResponse(state, "auth-code-123", null, null);
+
+        verify(appleIdentityProvider).prepareClientSecret("com.example.app");
+        verify(appleIdentityProvider).sendTokenRequest(eq("auth-code-123"), eq("com.example.app"), isNull(), eq(authSession), anyString());
+        verify(callback).authenticated(federatedIdentity);
+    }
+
+    @Test
+    void authResponse_withAuthorizationCodeAndUserData_passesUserToSendTokenRequest() throws Exception {
+        String state = createValidState();
+        BrokeredIdentityContext federatedIdentity = mock(BrokeredIdentityContext.class);
+        when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+        when(appleIdentityProvider.sendTokenRequest(anyString(), anyString(), anyString(), any(), anyString()))
+                .thenReturn(federatedIdentity);
+
+        String userJson = "{\"name\":{\"firstName\":\"John\"}}";
+        endpoint.authResponse(state, "auth-code-123", userJson, null);
+
+        verify(appleIdentityProvider).sendTokenRequest(eq("auth-code-123"), eq("com.example.app"), eq(userJson), eq(authSession), anyString());
+    }
+
+    @Test
+    void authResponse_sendTokenRequestReturnsNull_doesNotCallAuthenticated() throws Exception {
+        try (MockedStatic<ErrorPage> errorPageMock = mockStatic(ErrorPage.class)) {
+            String state = createValidState();
+            when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+            when(appleIdentityProvider.sendTokenRequest(anyString(), anyString(), any(), any(), anyString()))
+                    .thenReturn(null);
+
+            endpoint.authResponse(state, "auth-code-123", null, null);
+
+            verify(callback, never()).authenticated(any());
+        }
+    }
+
+    @Test
+    void authResponse_sendTokenRequestThrowsException_doesNotCallAuthenticated() throws Exception {
+        try (MockedStatic<ErrorPage> errorPageMock = mockStatic(ErrorPage.class)) {
+            String state = createValidState();
+            when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+            when(appleIdentityProvider.sendTokenRequest(anyString(), anyString(), any(), any(), anyString()))
+                    .thenThrow(new RuntimeException("Network error"));
+
+            endpoint.authResponse(state, "auth-code-123", null, null);
+
+            verify(callback, never()).authenticated(any());
+        }
+    }
+
+    @Test
+    void authResponse_nullAuthorizationCode_doesNotCallSendTokenRequest() throws Exception {
+        try (MockedStatic<ErrorPage> errorPageMock = mockStatic(ErrorPage.class)) {
+            String state = createValidState();
+            when(callback.getAndVerifyAuthenticationSession(state)).thenReturn(authSession);
+
+            endpoint.authResponse(state, null, null, null);
+
+            verify(appleIdentityProvider, never()).sendTokenRequest(any(), any(), any(), any(), any());
+            verify(callback, never()).authenticated(any());
+        }
+    }
+
+    // ========== Helpers ==========
+
+    private String createValidState() {
+        String encodedClientId = Base64Url.encode("client".getBytes(StandardCharsets.UTF_8));
+        return "state123.tab456." + encodedClientId;
+    }
+}

--- a/src/test/java/at/klausbetz/provider/AppleIdentityProviderFactoryTest.java
+++ b/src/test/java/at/klausbetz/provider/AppleIdentityProviderFactoryTest.java
@@ -1,0 +1,93 @@
+package at.klausbetz.provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class AppleIdentityProviderFactoryTest {
+
+    @Mock(lenient = true)
+    private KeycloakSession session;
+
+    private AppleIdentityProviderFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new AppleIdentityProviderFactory();
+    }
+
+    @Test
+    void whenGetName_thenReturnsApple() {
+        assertEquals("Apple", factory.getName());
+    }
+
+    @Test
+    void whenGetId_thenReturnsApple() {
+        assertEquals("apple", factory.getId());
+    }
+
+    @Test
+    void whenCreateConfig_thenReturnsAppleIdentityProviderConfig() {
+        AppleIdentityProviderConfig config = factory.createConfig();
+        assertNotNull(config);
+        assertInstanceOf(AppleIdentityProviderConfig.class, config);
+    }
+
+    @Test
+    void givenSessionAndModel_whenCreate_thenReturnsAppleIdentityProvider() {
+        IdentityProviderModel model = new IdentityProviderModel();
+        model.setProviderId("apple");
+        AppleIdentityProvider provider = factory.create(session, model);
+        assertNotNull(provider);
+    }
+
+    @Test
+    void whenGetConfigProperties_thenContainsExpectedProperties() {
+        List<ProviderConfigProperty> properties = factory.getConfigProperties();
+        assertNotNull(properties);
+        assertFalse(properties.isEmpty());
+
+        List<String> propertyNames = properties.stream().map(ProviderConfigProperty::getName).toList();
+        assertTrue(propertyNames.contains("displayName"));
+        assertTrue(propertyNames.contains("teamId"));
+        assertTrue(propertyNames.contains("keyId"));
+        assertTrue(propertyNames.contains("tokenExchangeAccountLinkingEnabled"));
+    }
+
+    @Test
+    void whenGetConfigProperties_thenTeamIdHasCorrectType() {
+        List<ProviderConfigProperty> properties = factory.getConfigProperties();
+        ProviderConfigProperty teamId = properties.stream()
+                .filter(p -> "teamId".equals(p.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(ProviderConfigProperty.STRING_TYPE, teamId.getType());
+        assertNotNull(teamId.getLabel());
+        assertNotNull(teamId.getHelpText());
+    }
+
+    @Test
+    void whenGetConfigProperties_thenTokenExchangeAccountLinkingHasBooleanType() {
+        List<ProviderConfigProperty> properties = factory.getConfigProperties();
+        ProviderConfigProperty tokenExchange = properties.stream()
+                .filter(p -> "tokenExchangeAccountLinkingEnabled".equals(p.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(ProviderConfigProperty.BOOLEAN_TYPE, tokenExchange.getType());
+    }
+
+    @Test
+    void whenProviderIdConstant_thenEqualsApple() {
+        assertEquals("apple", AppleIdentityProviderFactory.PROVIDER_ID);
+    }
+}

--- a/src/test/java/at/klausbetz/provider/AppleIdentityProviderTest.java
+++ b/src/test/java/at/klausbetz/provider/AppleIdentityProviderTest.java
@@ -1,0 +1,503 @@
+package at.klausbetz.provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.models.*;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.services.ErrorResponseException;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AppleIdentityProviderTest {
+
+    @Mock(lenient = true)
+    private KeycloakSession session;
+
+    @Mock(lenient = true)
+    private EventBuilder event;
+
+    private AppleIdentityProviderConfig config;
+    private AppleIdentityProvider provider;
+    private IdentityProviderModel idpModel;
+
+    @BeforeEach
+    void setUp() {
+        idpModel = new IdentityProviderModel();
+        idpModel.setProviderId("apple");
+        config = new AppleIdentityProviderConfig(idpModel);
+        config.setAlias("apple");
+        config.setClientId("com.example.app");
+        config.setTeamId("ABCDE12345");
+        config.setKeyId("KEY1234567");
+        provider = new AppleIdentityProvider(session, config);
+    }
+
+    // ========== Constructor tests ==========
+
+    @Nested
+    class ConstructorTests {
+        @Test
+        void setsAuthorizationUrl() {
+            assertEquals("https://appleid.apple.com/auth/authorize?response_mode=form_post", config.getAuthorizationUrl());
+        }
+
+        @Test
+        void setsTokenUrl() {
+            assertEquals("https://appleid.apple.com/auth/token", config.getTokenUrl());
+        }
+
+        @Test
+        void setsJwksUrl() {
+            assertEquals("https://appleid.apple.com/auth/keys", config.getJwksUrl());
+        }
+
+        @Test
+        void setsValidateSignatureToTrue() {
+            assertTrue(config.isValidateSignature());
+        }
+
+        @Test
+        void setsUseJwksUrlToTrue() {
+            assertTrue(config.isUseJwksUrl());
+        }
+
+        @Test
+        void setsClientAuthMethodToPost() {
+            assertEquals(OIDCLoginProtocol.CLIENT_SECRET_POST, config.getClientAuthMethod());
+        }
+
+        @Test
+        void setsIssuer() {
+            assertEquals("https://appleid.apple.com", config.getIssuer());
+        }
+    }
+
+    // ========== Basic method tests ==========
+
+    @Test
+    void getDefaultScopes_returnsNameAndEmail() {
+        // The parent constructor sets defaultScope from getDefaultScopes() and prepends "openid"
+        String scope = config.getDefaultScope();
+        assertTrue(scope.contains("name%20email"));
+        assertTrue(scope.contains("openid"));
+    }
+
+    @Test
+    void getConfig_returnsAppleIdentityProviderConfig() {
+        assertInstanceOf(AppleIdentityProviderConfig.class, provider.getConfig());
+        assertSame(config, provider.getConfig());
+    }
+
+    @Test
+    void callback_returnsAppleIdentityProviderEndpoint() {
+        RealmModel realm = mock(RealmModel.class);
+        EventBuilder eventBuilder = mock(EventBuilder.class);
+        Object endpoint = provider.callback(realm, mock(org.keycloak.broker.provider.UserAuthenticationIdentityProvider.AuthenticationCallback.class), eventBuilder);
+        assertInstanceOf(AppleIdentityProviderEndpoint.class, endpoint);
+    }
+
+    // ========== parseUser tests (via reflection) ==========
+
+    @Nested
+    class ParseUserTests {
+
+        @Test
+        void withFullUserJson_parsesAllFields() throws Exception {
+            String userJson = "{\"name\":{\"firstName\":\"John\",\"lastName\":\"Doe\"},\"email\":\"john@example.com\"}";
+            AppleUserRepresentation result = invokeParseUser(userJson);
+
+            assertEquals("John", result.getFirstName());
+            assertEquals("Doe", result.getLastName());
+            assertEquals("john@example.com", result.getEmail());
+            assertNotNull(result.getProfile());
+        }
+
+        @Test
+        void withNameOnly_parsesNameFieldsAndEmailIsNull() throws Exception {
+            String userJson = "{\"name\":{\"firstName\":\"Jane\",\"lastName\":\"Smith\"}}";
+            AppleUserRepresentation result = invokeParseUser(userJson);
+
+            assertEquals("Jane", result.getFirstName());
+            assertEquals("Smith", result.getLastName());
+            assertNull(result.getEmail());
+        }
+
+        @Test
+        void withFirstNameOnly_parsesFirstNameOnly() throws Exception {
+            String userJson = "{\"name\":{\"firstName\":\"Jane\"}}";
+            AppleUserRepresentation result = invokeParseUser(userJson);
+
+            assertEquals("Jane", result.getFirstName());
+            assertNull(result.getLastName());
+        }
+
+        @Test
+        void withEmailButNoName_emailIsNotParsed() throws Exception {
+            // This documents a known bug: email extraction is nested inside the nameNode != null block
+            String userJson = "{\"email\":\"john@example.com\"}";
+            AppleUserRepresentation result = invokeParseUser(userJson);
+
+            assertNull(result.getFirstName());
+            assertNull(result.getLastName());
+            assertNull(result.getEmail()); // BUG: email is not parsed when name is absent
+            assertNotNull(result.getProfile());
+        }
+
+        @Test
+        void withEmptyJson_returnsEmptyRepresentation() throws Exception {
+            AppleUserRepresentation result = invokeParseUser("{}");
+
+            assertNull(result.getFirstName());
+            assertNull(result.getLastName());
+            assertNull(result.getEmail());
+            assertNotNull(result.getProfile());
+        }
+
+        @Test
+        void withEmptyNameObject_returnsEmptyRepresentation() throws Exception {
+            String userJson = "{\"name\":{},\"email\":\"john@example.com\"}";
+            AppleUserRepresentation result = invokeParseUser(userJson);
+
+            assertNull(result.getFirstName());
+            assertNull(result.getLastName());
+            // email IS parsed here because nameNode is not null (it's an empty object)
+            assertEquals("john@example.com", result.getEmail());
+        }
+
+        @Test
+        void withMalformedJson_throwsJsonProcessingException() {
+            assertThrows(InvocationTargetException.class, () -> invokeParseUser("not json"));
+        }
+    }
+
+    // ========== handleUserJson tests (via reflection) ==========
+
+    @Nested
+    class HandleUserJsonTests {
+
+        @Test
+        void setsFieldsWhenContextFieldsAreNull() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            String userJson = "{\"name\":{\"firstName\":\"John\",\"lastName\":\"Doe\"},\"email\":\"john@example.com\"}";
+
+            BrokeredIdentityContext result = invokeHandleUserJson(context, userJson);
+
+            assertEquals("John", result.getFirstName());
+            assertEquals("Doe", result.getLastName());
+            assertEquals("john@example.com", result.getEmail());
+        }
+
+        @Test
+        void setsFieldsWhenContextFieldsAreBlank() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            context.setFirstName("   ");
+            context.setLastName("   ");
+            context.setEmail("   ");
+            String userJson = "{\"name\":{\"firstName\":\"John\",\"lastName\":\"Doe\"},\"email\":\"john@example.com\"}";
+
+            BrokeredIdentityContext result = invokeHandleUserJson(context, userJson);
+
+            assertEquals("John", result.getFirstName());
+            assertEquals("Doe", result.getLastName());
+            assertEquals("john@example.com", result.getEmail());
+        }
+
+        @Test
+        void doesNotOverrideExistingFields() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            context.setFirstName("Existing");
+            context.setLastName("User");
+            context.setEmail("existing@example.com");
+            String userJson = "{\"name\":{\"firstName\":\"John\",\"lastName\":\"Doe\"},\"email\":\"john@example.com\"}";
+
+            BrokeredIdentityContext result = invokeHandleUserJson(context, userJson);
+
+            assertEquals("Existing", result.getFirstName());
+            assertEquals("User", result.getLastName());
+            assertEquals("existing@example.com", result.getEmail());
+        }
+
+        @Test
+        void malformedJson_returnsContextUnchanged() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            context.setFirstName("Existing");
+
+            BrokeredIdentityContext result = invokeHandleUserJson(context, "not valid json");
+
+            assertSame(context, result);
+            assertEquals("Existing", result.getFirstName());
+        }
+
+        @Test
+        void partialUserJson_setsOnlyAvailableFields() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            String userJson = "{\"name\":{\"firstName\":\"John\"}}";
+
+            BrokeredIdentityContext result = invokeHandleUserJson(context, userJson);
+
+            assertEquals("John", result.getFirstName());
+            assertNull(result.getLastName());
+        }
+    }
+
+    // ========== isValidSecret tests (via reflection) ==========
+
+    @Nested
+    class IsValidSecretTests {
+
+        @Test
+        void withNull_returnsFalse() throws Exception {
+            assertFalse(invokeIsValidSecret(null));
+        }
+
+        @Test
+        void withEmptyString_returnsFalse() throws Exception {
+            assertFalse(invokeIsValidSecret(""));
+        }
+
+        @Test
+        void withNonJwsString_returnsFalse() throws Exception {
+            assertFalse(invokeIsValidSecret("not-a-jws-token"));
+        }
+
+        @Test
+        void withRandomString_returnsFalse() throws Exception {
+            assertFalse(invokeIsValidSecret("abc.def.ghi"));
+        }
+    }
+
+    // ========== generateClientToken tests (via reflection) ==========
+
+    @Nested
+    class GenerateClientTokenTests {
+
+        @Test
+        void setsCorrectClaims() throws Exception {
+            JsonWebToken token = invokeGenerateClientToken("TEAM123", "com.example.app");
+
+            assertEquals("TEAM123", token.getIssuer());
+            assertEquals("com.example.app", token.getSubject());
+            String[] audience = token.getAudience();
+            assertNotNull(audience);
+            assertEquals("https://appleid.apple.com", audience[0]);
+            assertNotNull(token.getIat());
+            assertTrue(token.getExp() > token.getIat());
+        }
+
+        @Test
+        void expiresIn180Days() throws Exception {
+            JsonWebToken token = invokeGenerateClientToken("TEAM123", "com.example.app");
+
+            long expectedDuration = 86400L * 180;
+            assertEquals(expectedDuration, token.getExp() - token.getIat());
+        }
+    }
+
+    // ========== exchangeExternalTokenV1Impl tests ==========
+
+    @Nested
+    class ExchangeExternalTokenTests {
+
+        @Test
+        void nullSubjectToken_throwsErrorResponseWithInvalidToken() {
+            MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+
+            ErrorResponseException ex = assertThrows(ErrorResponseException.class,
+                    () -> provider.exchangeExternalTokenV1Impl(event, params));
+
+            assertEquals(400, ex.getResponse().getStatus());
+            verify(event).error(Errors.INVALID_TOKEN);
+        }
+
+        @Test
+        void invalidTokenType_throwsErrorResponseWithInvalidTokenType() {
+            MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+            params.putSingle(OAuth2Constants.SUBJECT_TOKEN, "someToken");
+            params.putSingle(OAuth2Constants.SUBJECT_TOKEN_TYPE, "unsupported-type");
+
+            ErrorResponseException ex = assertThrows(ErrorResponseException.class,
+                    () -> provider.exchangeExternalTokenV1Impl(event, params));
+
+            assertEquals(400, ex.getResponse().getStatus());
+            verify(event).error(Errors.INVALID_TOKEN_TYPE);
+        }
+    }
+
+    // ========== autoLinkIfPossible tests (via reflection) ==========
+
+    @Nested
+    class AutoLinkIfPossibleTests {
+
+        @Mock(lenient = true)
+        private KeycloakContext keycloakContext;
+
+        @Mock(lenient = true)
+        private RealmModel realm;
+
+        @Mock(lenient = true)
+        private UserProvider userProvider;
+
+        @BeforeEach
+        void setUpMocks() {
+            lenient().when(session.getContext()).thenReturn(keycloakContext);
+            lenient().when(keycloakContext.getRealm()).thenReturn(realm);
+            lenient().when(session.users()).thenReturn(userProvider);
+        }
+
+        @Test
+        void blankEmail_doesNotQueryUsers() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            context.setEmail("   ");
+
+            invokeAutoLinkIfPossible(context);
+
+            verifyNoInteractions(userProvider);
+        }
+
+        @Test
+        void nullEmail_doesNotQueryUsers() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            context.setEmail(null);
+
+            invokeAutoLinkIfPossible(context);
+
+            verifyNoInteractions(userProvider);
+        }
+
+        @Test
+        void noExistingUser_doesNotLink() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            context.setEmail("unknown@example.com");
+            when(userProvider.getUserByEmail(realm, "unknown@example.com")).thenReturn(null);
+
+            invokeAutoLinkIfPossible(context);
+
+            verify(userProvider, never()).addFederatedIdentity(any(), any(), any());
+        }
+
+        @Test
+        void alreadyLinked_doesNotAddNewLink() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            context.setEmail("linked@example.com");
+            UserModel existingUser = mock(UserModel.class);
+            FederatedIdentityModel existingLink = mock(FederatedIdentityModel.class);
+            when(userProvider.getUserByEmail(realm, "linked@example.com")).thenReturn(existingUser);
+            when(userProvider.getFederatedIdentity(realm, existingUser, "apple")).thenReturn(existingLink);
+
+            invokeAutoLinkIfPossible(context);
+
+            verify(userProvider, never()).addFederatedIdentity(any(), any(), any());
+        }
+
+        @Test
+        void existingUserNotLinked_addsNewFederatedIdentity() throws Exception {
+            BrokeredIdentityContext context = createContext();
+            context.setId("apple-sub-123");
+            context.setUsername("appleuser");
+            context.setEmail("user@example.com");
+            UserModel existingUser = mock(UserModel.class);
+            when(userProvider.getUserByEmail(realm, "user@example.com")).thenReturn(existingUser);
+            when(userProvider.getFederatedIdentity(realm, existingUser, "apple")).thenReturn(null);
+
+            invokeAutoLinkIfPossible(context);
+
+            verify(userProvider).addFederatedIdentity(eq(realm), eq(existingUser), any(FederatedIdentityModel.class));
+        }
+    }
+
+    // ========== getFederatedIdentity(String, String) tests ==========
+
+    @Nested
+    class GetFederatedIdentityWithUserDataTests {
+
+        @Test
+        void withUserData_setsNameAndStoresProfile() throws Exception {
+            AppleIdentityProvider spy = spy(provider);
+            BrokeredIdentityContext mockContext = createContext();
+            doReturn(mockContext).when(spy).getFederatedIdentity(anyString());
+
+            String userData = "{\"name\":{\"firstName\":\"John\",\"lastName\":\"Doe\"},\"email\":\"john@example.com\"}";
+            BrokeredIdentityContext result = spy.getFederatedIdentity(userData, "{}");
+
+            assertEquals("John", result.getFirstName());
+            assertEquals("Doe", result.getLastName());
+        }
+
+        @Test
+        void withoutUserData_doesNotSetNames() throws Exception {
+            AppleIdentityProvider spy = spy(provider);
+            BrokeredIdentityContext mockContext = createContext();
+            doReturn(mockContext).when(spy).getFederatedIdentity(anyString());
+
+            BrokeredIdentityContext result = spy.getFederatedIdentity(null, "{}");
+
+            assertNull(result.getFirstName());
+            assertNull(result.getLastName());
+        }
+
+        @Test
+        void withUserData_storesProfileInContextData() throws Exception {
+            AppleIdentityProvider spy = spy(provider);
+            BrokeredIdentityContext mockContext = createContext();
+            doReturn(mockContext).when(spy).getFederatedIdentity(anyString());
+
+            String userData = "{\"name\":{\"firstName\":\"John\"}}";
+            BrokeredIdentityContext result = spy.getFederatedIdentity(userData, "{}");
+
+            // AbstractJsonUserAttributeMapper stores profile under OIDCIdentityProvider.USER_INFO key
+            assertNotNull(result.getContextData().get("UserInfo"));
+        }
+    }
+
+    // ========== Reflection helper methods ==========
+
+    private AppleUserRepresentation invokeParseUser(String userJson) throws Exception {
+        Method method = AppleIdentityProvider.class.getDeclaredMethod("parseUser", String.class);
+        method.setAccessible(true);
+        return (AppleUserRepresentation) method.invoke(provider, userJson);
+    }
+
+    private BrokeredIdentityContext invokeHandleUserJson(BrokeredIdentityContext context, String userJson) throws Exception {
+        Method method = AppleIdentityProvider.class.getDeclaredMethod("handleUserJson", BrokeredIdentityContext.class, String.class);
+        method.setAccessible(true);
+        return (BrokeredIdentityContext) method.invoke(provider, context, userJson);
+    }
+
+    private boolean invokeIsValidSecret(String clientSecret) throws Exception {
+        Method method = AppleIdentityProvider.class.getDeclaredMethod("isValidSecret", String.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(provider, clientSecret);
+    }
+
+    private JsonWebToken invokeGenerateClientToken(String teamId, String clientId) throws Exception {
+        Method method = AppleIdentityProvider.class.getDeclaredMethod("generateClientToken", String.class, String.class);
+        method.setAccessible(true);
+        return (JsonWebToken) method.invoke(provider, teamId, clientId);
+    }
+
+    private void invokeAutoLinkIfPossible(BrokeredIdentityContext context) throws Exception {
+        Method method = AppleIdentityProvider.class.getDeclaredMethod("autoLinkIfPossible", BrokeredIdentityContext.class);
+        method.setAccessible(true);
+        method.invoke(provider, context);
+    }
+
+    private BrokeredIdentityContext createContext() {
+        return new BrokeredIdentityContext("test-id", idpModel);
+    }
+}

--- a/src/test/java/at/klausbetz/provider/AppleMapperTest.java
+++ b/src/test/java/at/klausbetz/provider/AppleMapperTest.java
@@ -1,0 +1,68 @@
+package at.klausbetz.provider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AppleMapperTest {
+
+    // ========== AppleUsernameTemplateMapper ==========
+
+    @Test
+    void usernameTemplateMapper_getCompatibleProviders_returnsApple() {
+        AppleUsernameTemplateMapper mapper = new AppleUsernameTemplateMapper();
+        String[] providers = mapper.getCompatibleProviders();
+        assertArrayEquals(new String[]{"apple"}, providers);
+    }
+
+    @Test
+    void usernameTemplateMapper_getId_returnsExpectedId() {
+        AppleUsernameTemplateMapper mapper = new AppleUsernameTemplateMapper();
+        assertEquals("apple-username-template-mapper", mapper.getId());
+    }
+
+    // ========== AppleUserAttributeMapper ==========
+
+    @Test
+    void userAttributeMapper_getCompatibleProviders_returnsApple() {
+        AppleUserAttributeMapper mapper = new AppleUserAttributeMapper();
+        String[] providers = mapper.getCompatibleProviders();
+        assertArrayEquals(new String[]{"apple"}, providers);
+    }
+
+    @Test
+    void userAttributeMapper_getId_returnsExpectedId() {
+        AppleUserAttributeMapper mapper = new AppleUserAttributeMapper();
+        assertEquals("apple-user-attribute-mapper", mapper.getId());
+    }
+
+    // ========== AppleJsonUserAttributeMapper ==========
+
+    @Test
+    void jsonUserAttributeMapper_getCompatibleProviders_returnsApple() {
+        AppleJsonUserAttributeMapper mapper = new AppleJsonUserAttributeMapper();
+        String[] providers = mapper.getCompatibleProviders();
+        assertArrayEquals(new String[]{"apple"}, providers);
+    }
+
+    @Test
+    void jsonUserAttributeMapper_getId_returnsExpectedId() {
+        AppleJsonUserAttributeMapper mapper = new AppleJsonUserAttributeMapper();
+        assertEquals("apple-json-user-attribute-mapper", mapper.getId());
+    }
+
+    // ========== AppleUserSessionNoteMapper ==========
+
+    @Test
+    void userSessionNoteMapper_getCompatibleProviders_returnsApple() {
+        AppleUserSessionNoteMapper mapper = new AppleUserSessionNoteMapper();
+        String[] providers = mapper.getCompatibleProviders();
+        assertArrayEquals(new String[]{"apple"}, providers);
+    }
+
+    @Test
+    void userSessionNoteMapper_getId_returnsExpectedId() {
+        AppleUserSessionNoteMapper mapper = new AppleUserSessionNoteMapper();
+        assertEquals("apple-claim-user-session-note-mapper", mapper.getId());
+    }
+}

--- a/src/test/java/at/klausbetz/provider/MultivaluedMapBuilder.java
+++ b/src/test/java/at/klausbetz/provider/MultivaluedMapBuilder.java
@@ -31,6 +31,11 @@ public class MultivaluedMapBuilder {
         return this;
     }
 
+    public MultivaluedMapBuilder appRedirectUri(String appRedirectUri) {
+        params.put("app_redirect_uri", appRedirectUri != null ? List.of(appRedirectUri) : Collections.emptyList());
+        return this;
+    }
+
     public MultivaluedMap<String, String> build() {
         return params;
     }

--- a/src/test/java/at/klausbetz/provider/TokenExchangeParamsTest.java
+++ b/src/test/java/at/klausbetz/provider/TokenExchangeParamsTest.java
@@ -86,4 +86,28 @@ class TokenExchangeParamsTest {
         assertNull(exchangeParams.getUserJson());
         assertNull(exchangeParams.getAppIdentifier());
     }
+
+    @Test
+    void givenValidExchangeRequestWithAppRedirectUri_whenCreatingTokenExchangeParams_thenRedirectUriIsParsed() {
+        MultivaluedMap<String, String> params = new MultivaluedMapBuilder().subjectToken("myFancyAppleAuthorizationCode").appRedirectUri("https://example.com/callback").build();
+        TokenExchangeParams exchangeParams = new TokenExchangeParams(params);
+
+        assertEquals("https://example.com/callback", exchangeParams.getAppRedirectUri());
+    }
+
+    @Test
+    void givenValidExchangeRequestWithBlankAppRedirectUri_whenCreatingTokenExchangeParams_thenRedirectUriIsNormalized() {
+        MultivaluedMap<String, String> params = new MultivaluedMapBuilder().subjectToken("myFancyAppleAuthorizationCode").appRedirectUri("   ").build();
+        TokenExchangeParams exchangeParams = new TokenExchangeParams(params);
+
+        assertNull(exchangeParams.getAppRedirectUri());
+    }
+
+    @Test
+    void givenValidExchangeRequestWithNullAppRedirectUri_whenCreatingTokenExchangeParams_thenRedirectUriIsNull() {
+        MultivaluedMap<String, String> params = new MultivaluedMapBuilder().subjectToken("myFancyAppleAuthorizationCode").appRedirectUri(null).build();
+        TokenExchangeParams exchangeParams = new TokenExchangeParams(params);
+
+        assertNull(exchangeParams.getAppRedirectUri());
+    }
 }


### PR DESCRIPTION
## Summary

- Add 87 unit tests covering all provider classes: `AppleIdentityProvider`, `AppleIdentityProviderEndpoint`, `AppleIdentityProviderConfig`, `AppleIdentityProviderFactory`, all 4 mappers, and `TokenExchangeParams`
- Bump Java from 17 to 21 across CI workflows (`ci.yml`, `release.yml`, `jitpack.yml`) and `build.gradle` to align with Keycloak 26.x runtime
- Upgrade Gradle wrapper from 8.0.2 to 8.10.2 (Java 21 support)
- Modernize GitHub Actions: replace deprecated `gradle/gradle-build-action` and `gradle/wrapper-validation-action` with `gradle/actions/setup-gradle@v4`

## Test coverage

| Class | Tests | What's covered |
|---|---|---|
| `AppleIdentityProviderConfig` | 13 | Getters/setters, defaults, displayName fallback |
| `AppleIdentityProviderFactory` | 8 | Factory methods, config properties |
| `AppleIdentityProvider` | 24 | Constructor, parseUser, handleUserJson, isValidSecret, generateClientToken, exchangeExternalTokenV1Impl, autoLinkIfPossible, getFederatedIdentity |
| `AppleIdentityProviderEndpoint` | 10 | authResponse branches (error types, success, null code, exceptions) |
| `AppleMapperTest` | 8 | 4 mappers x (compatibleProviders + getId) |
| `TokenExchangeParams` | 10 | All fields including appRedirectUri normalization |

## Test plan

- [x] All 87 tests pass locally on Java 21
- [x] CI pipeline runs tests and displays individual results
- [x] Verify CI passes on GitHub after push
